### PR TITLE
chore: update module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 
-module github.com/banacontrol/doh
+module github.com/banacontrol/smartdns
 
 go 1.22.0
 

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,1 @@
+github.com/miekg/dns v1.1.59/go.mod h1:nZpewl5p6IvctfgrckopVx2OlSEHPRO/U4SYkRklrEk=


### PR DESCRIPTION
## Summary
- update Go module path to use github.com/banacontrol/smartdns
- run go mod tidy (fails to fetch dependencies)

## Testing
- `go mod tidy` *(fails: unrecognized import path "golang.org/x/net": Forbidden)*
- `go build ./...` *(fails: missing go.sum entry for github.com/miekg/dns)*

------
https://chatgpt.com/codex/tasks/task_b_68ae3ae249848326898979a54e7a8c1f